### PR TITLE
Addition of funtions to iterate over full decklists and to get top commander by color identity or by timeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ top_planeswalkers = edhrec.get_top_planeswalkers(miirym)
 top_utility_lands = edhrec.get_top_utility_lands(miirym)
 top_lands = edhrec.get_top_lands(miirym)
 
+# Iterate over known decklists for a commander
+for list in edhrec.get_commander_decklists(miirym):
+    next_deck = list
+
+# All known decklists for a commander 
+all = list(edhrec.get_commander_decklists(miirym))
+
+# Get top commanders by timeframe as generator (default number is 100)
+week = edhrec.get_top_commanders_by_timeframe(time_frame="week")
+all_times = edhrec.get_top_commanders_by_timeframe()
+
+# Get top commanders by color identity as generator (default number is 100)
+mono_white = edhrec.get_top_commanders_by_color(colors=["w"])
+colorless = edhrec.get_top_commanders_by_color(colors=["c"])
+simic = edhrec.get_top_commanders_by_color(colors=["u", "g"])
+izzet = edhrec.get_top_commanders_by_color(colors=["u", "r"])
+esper = edhrec.get_top_commanders_by_color(colors=["u", "w", "b"])
+five_colors = edhrec.get_top_commanders_by_color(colors=["u", "w", "b", "g", "r"])
+
 ```
 
 ## Caching

--- a/src/edhrec/pyedhrec.py
+++ b/src/edhrec/pyedhrec.py
@@ -250,3 +250,11 @@ class EDHRec:
     def get_top_utility_lands(self, card_name: str) -> dict:
         card_list = self._get_cardlist_from_container(card_name, "utilitylands")
         return card_list
+
+    def get_deck_by_id(self, id):
+        deck_by_id_uri, params = self._build_nextjs_uri("deckpreview", id)
+        deck_by_id_uri = deck_by_id_uri.replace(self.format_card_name(id), id)
+        res = self._get(deck_by_id_uri, query_params=params)
+        data = self._get_nextjs_data(res)
+        return data
+

--- a/src/edhrec/pyedhrec.py
+++ b/src/edhrec/pyedhrec.py
@@ -278,7 +278,10 @@ class EDHRec:
         decklists_container = self.get_commander_decks(card_name, budget)["table"]
         for dl in decklists_container:
             hash = dl["urlhash"]
-            yield self.get_deck_by_id(hash, simplified_output=True)
+            try:
+                yield self.get_deck_by_id(hash, simplified_output=True)
+            except requests.exceptions.HTTPError:
+                pass
 
     def _get_top_commanders(self, query: str, n: int = 100):
         top_commanders_uri, params = self._build_nextjs_uri("commanders", query)

--- a/src/edhrec/pyedhrec.py
+++ b/src/edhrec/pyedhrec.py
@@ -115,7 +115,7 @@ class EDHRec:
             return response.get("pageProps", {}).get("data")
 
     def _get_cardlist_from_container(self, card_name: str, tag: str = None) -> dict:
-        card_data = self.get_commander_data(card_name)
+        card_data = self.get_card_data(card_name)
         container = card_data.get("container", {})
         json_dict = container.get("json_dict", {})
         card_lists = json_dict.get("cardlists")
@@ -173,6 +173,12 @@ class EDHRec:
     @commander_cache
     def get_commander_data(self, card_name: str) -> dict:
         commander_uri, params = self._build_nextjs_uri("commanders", card_name)
+        res = self._get(commander_uri, query_params=params)
+        data = self._get_nextjs_data(res)
+        return data
+
+    def get_card_data(self, card_name: str) -> dict:
+        commander_uri, params = self._build_nextjs_uri("cards", card_name)
         res = self._get(commander_uri, query_params=params)
         data = self._get_nextjs_data(res)
         return data

--- a/src/edhrec/pyedhrec.py
+++ b/src/edhrec/pyedhrec.py
@@ -288,7 +288,6 @@ class EDHRec:
         res = self._get(top_commanders_uri, query_params=params)
         data = self._get_nextjs_data(res)
         cardlist = data["container"]["json_dict"]["cardlists"][0]
-        # print(len(data["container"]["json_dict"]["cardlists"][0]["cardviews"]))
         for i in range(n):
             local_index, global_index = i % 100, i // 100
             if (local_index == 0) and (global_index != 0):
@@ -296,10 +295,7 @@ class EDHRec:
                 top_commanders_uri = top_commanders_uri[:replace_index] + cardlist["more"]
                 res = self._get(top_commanders_uri)
                 cardlist = self._get_nextjs_data(res)
-            yield cardlist["cardviews"][local_index]["name"]  # , data
-
-        # return data
-        # https: // edhrec.com / _next / data / lIhytebIvWgHKzJgHnn1i / commanders.json
+            yield cardlist["cardviews"][local_index]["name"]
 
     def get_top_commanders_by_timeframe(self, time_frame: str = "", n: int = 100):
         """
@@ -333,41 +329,3 @@ class EDHRec:
         query = archetype
         for i in self._get_top_commanders(query=query, n=n):
             yield i
-
-    # def get_top_commanders(self, time_frame="",colors = [],  n=100):
-    #
-    #     color_archetypes = {'w': 'mono-white', 'u': 'mono-blue', 'b': 'mono-black', 'r': 'mono-red', 'g': 'mono-green',
-    #                         'c': 'colorless', 'uw': 'azorius', 'bu': 'dimir', 'br': 'rakdos', 'gr': 'gruul',
-    #                         'gw': 'selesnya', 'bw': 'orzhov', 'ru': 'izzet', 'bg': 'golgari', 'rw': 'boros',
-    #                         'gu': 'simic', 'buw': 'esper', 'bru': 'grixis', 'bgr': 'jund', 'grw': 'naya', 'guw': 'bant',
-    #                         'bgw': 'abzan', 'ruw': 'jeskai', 'bgu': 'sultai', 'brw': 'mardu', 'gru': 'temur',
-    #                         'bruw': 'yore-tiller', 'bgru': 'glint-eye', 'bgrw': 'dune-brood', 'gruw': 'ink-treader',
-    #                         'bguw': 'witch-maw', 'bgruw': 'five-color'} # need to find a better way
-    #
-    #     assert time_frame in (
-    #         "week", "month", ""), "The available time frames are week and month, leave empty for all times"
-    #     if len(colors) > 0:
-    #         color_sting = "".join(sorted(colors))
-    #         archetype = color_archetypes[color_sting]
-    #         query = archetype
-    #     else:
-    #         query = time_frame
-    #     top_commanders_uri, params = self._build_nextjs_uri("commanders", query)
-    #     if time_frame == "" and len(colors) == 0:
-    #         top_commanders_uri = top_commanders_uri.replace("commanders/.json", "commanders.json")
-    #
-    #     res = self._get(top_commanders_uri, query_params=params)
-    #     data = self._get_nextjs_data(res)
-    #     cardlist = data["container"]["json_dict"]["cardlists"][0]
-    #     # print(len(data["container"]["json_dict"]["cardlists"][0]["cardviews"]))
-    #     for i in range(n):
-    #         local_index, global_index = i % 100, i // 100
-    #         if (local_index == 0) and (global_index != 0):
-    #             replace_index = top_commanders_uri.find("commander")
-    #             top_commanders_uri = top_commanders_uri[:replace_index]+cardlist["more"]
-    #             res = self._get(top_commanders_uri)
-    #             cardlist = self._get_nextjs_data(res)
-    #         yield cardlist["cardviews"][local_index]["name"]# , data
-    #
-    #     # return data
-    #     # https: // edhrec.com / _next / data / lIhytebIvWgHKzJgHnn1i / commanders.json

--- a/src/edhrec/pyedhrec.py
+++ b/src/edhrec/pyedhrec.py
@@ -255,7 +255,7 @@ class EDHRec:
         """
         Fetch full deck list from EDHREC id/urlhash using the "deckpreview" endpoint
         :param id: id/urlhash of the deck of interest
-        :param simplified_output: if true the response is parsed into a eye-readable dict
+        :param simplified_output: if true the response is parsed into an eye-readable dict
         :return:
         """
         deck_by_id_uri, params = self._build_nextjs_uri("deckpreview", id)
@@ -266,10 +266,15 @@ class EDHRec:
             return data
         else:
             return {**{"Commander": [cm for cm in data["commanders"] if cm is not None]},
-                   **{cl["header"]: [card["name"] for card in cl["cardviews"]]
-                    for cl in data["container"]["json_dict"]["cardlists"]}}
+                    **{cl["header"]: [card["name"] for card in cl["cardviews"]]
+                       for cl in data["container"]["json_dict"]["cardlists"]}}
 
     def get_commander_decklists(self, card_name: str, budget: str = None) -> dict:
+        """
+        Generator of top deck lists for card_name commander, each iteration is a single request
+        :param card_name:
+        :param budget:
+        """
         decklists_container = self.get_commander_decks(card_name, budget)["table"]
         for dl in decklists_container:
             hash = dl["urlhash"]

--- a/src/edhrec/pyedhrec.py
+++ b/src/edhrec/pyedhrec.py
@@ -280,3 +280,94 @@ class EDHRec:
             hash = dl["urlhash"]
             yield self.get_deck_by_id(hash, simplified_output=True)
 
+    def _get_top_commanders(self, query: str, n: int = 100):
+        top_commanders_uri, params = self._build_nextjs_uri("commanders", query)
+        if len(query) == 0:
+            top_commanders_uri = top_commanders_uri.replace("commanders/.json", "commanders.json")
+
+        res = self._get(top_commanders_uri, query_params=params)
+        data = self._get_nextjs_data(res)
+        cardlist = data["container"]["json_dict"]["cardlists"][0]
+        # print(len(data["container"]["json_dict"]["cardlists"][0]["cardviews"]))
+        for i in range(n):
+            local_index, global_index = i % 100, i // 100
+            if (local_index == 0) and (global_index != 0):
+                replace_index = top_commanders_uri.find("commander")
+                top_commanders_uri = top_commanders_uri[:replace_index] + cardlist["more"]
+                res = self._get(top_commanders_uri)
+                cardlist = self._get_nextjs_data(res)
+            yield cardlist["cardviews"][local_index]["name"]  # , data
+
+        # return data
+        # https: // edhrec.com / _next / data / lIhytebIvWgHKzJgHnn1i / commanders.json
+
+    def get_top_commanders_by_timeframe(self, time_frame: str = "", n: int = 100):
+        """
+        Get list of top commanders for the specified timeframe
+        :param time_frame: available time frames are week and month, leave empty for all times
+        :param n: number of items to be returned, each 100 items will constitute a new request
+        """
+        assert time_frame in (
+            "week", "month", ""), "The available time frames are week and month, leave empty for all times"
+        query = time_frame
+        for i in self._get_top_commanders(query=query, n=n):
+            yield i
+
+    def get_top_commanders_by_color(self, colors: list = [], n: int = 100):
+        """
+        Get list of top commanders for the specified color combination
+        :param colors: list of color identifiers as sirings  e.g. ["w","b"] for orzhov
+        :param n: number of items to be returned, each 100 items will constitute a new request
+        """
+        color_archetypes = {'w': 'mono-white', 'u': 'mono-blue', 'b': 'mono-black', 'r': 'mono-red', 'g': 'mono-green',
+                            'c': 'colorless', 'uw': 'azorius', 'bu': 'dimir', 'br': 'rakdos', 'gr': 'gruul',
+                            'gw': 'selesnya', 'bw': 'orzhov', 'ru': 'izzet', 'bg': 'golgari', 'rw': 'boros',
+                            'gu': 'simic', 'buw': 'esper', 'bru': 'grixis', 'bgr': 'jund', 'grw': 'naya', 'guw': 'bant',
+                            'bgw': 'abzan', 'ruw': 'jeskai', 'bgu': 'sultai', 'brw': 'mardu', 'gru': 'temur',
+                            'bruw': 'yore-tiller', 'bgru': 'glint-eye', 'bgrw': 'dune-brood', 'gruw': 'ink-treader',
+                            'bguw': 'witch-maw', 'bgruw': 'five-color'}  # need to find a better way
+        color_sting = "".join(sorted(colors))
+        assert color_sting in color_archetypes.keys(), (f"Wrong color selection, available color combinations are: \n"
+                                                        f"{color_archetypes}")
+        archetype = color_archetypes[color_sting]
+        query = archetype
+        for i in self._get_top_commanders(query=query, n=n):
+            yield i
+
+    # def get_top_commanders(self, time_frame="",colors = [],  n=100):
+    #
+    #     color_archetypes = {'w': 'mono-white', 'u': 'mono-blue', 'b': 'mono-black', 'r': 'mono-red', 'g': 'mono-green',
+    #                         'c': 'colorless', 'uw': 'azorius', 'bu': 'dimir', 'br': 'rakdos', 'gr': 'gruul',
+    #                         'gw': 'selesnya', 'bw': 'orzhov', 'ru': 'izzet', 'bg': 'golgari', 'rw': 'boros',
+    #                         'gu': 'simic', 'buw': 'esper', 'bru': 'grixis', 'bgr': 'jund', 'grw': 'naya', 'guw': 'bant',
+    #                         'bgw': 'abzan', 'ruw': 'jeskai', 'bgu': 'sultai', 'brw': 'mardu', 'gru': 'temur',
+    #                         'bruw': 'yore-tiller', 'bgru': 'glint-eye', 'bgrw': 'dune-brood', 'gruw': 'ink-treader',
+    #                         'bguw': 'witch-maw', 'bgruw': 'five-color'} # need to find a better way
+    #
+    #     assert time_frame in (
+    #         "week", "month", ""), "The available time frames are week and month, leave empty for all times"
+    #     if len(colors) > 0:
+    #         color_sting = "".join(sorted(colors))
+    #         archetype = color_archetypes[color_sting]
+    #         query = archetype
+    #     else:
+    #         query = time_frame
+    #     top_commanders_uri, params = self._build_nextjs_uri("commanders", query)
+    #     if time_frame == "" and len(colors) == 0:
+    #         top_commanders_uri = top_commanders_uri.replace("commanders/.json", "commanders.json")
+    #
+    #     res = self._get(top_commanders_uri, query_params=params)
+    #     data = self._get_nextjs_data(res)
+    #     cardlist = data["container"]["json_dict"]["cardlists"][0]
+    #     # print(len(data["container"]["json_dict"]["cardlists"][0]["cardviews"]))
+    #     for i in range(n):
+    #         local_index, global_index = i % 100, i // 100
+    #         if (local_index == 0) and (global_index != 0):
+    #             replace_index = top_commanders_uri.find("commander")
+    #             top_commanders_uri = top_commanders_uri[:replace_index]+cardlist["more"]
+    #             res = self._get(top_commanders_uri)
+    #             cardlist = self._get_nextjs_data(res)
+    #         yield cardlist["cardviews"][local_index]["name"]# , data
+    #
+    #     # return data
+    #     # https: // edhrec.com / _next / data / lIhytebIvWgHKzJgHnn1i / commanders.json


### PR DESCRIPTION
I added just a few functions wich I found helpful form my needs.
I did not changed any part of the base code and reused it as much as possibile.
 
Usage example, taken from README 
```
# Iterate over known decklists for a commander
for list in edhrec.get_commander_decklists(miirym):
    next_deck = list

# All known decklists for a commander 
all = list(edhrec.get_commander_decklists(miirym))

# Get top commanders by timeframe as generator (default number is 100)
week = edhrec.get_top_commanders_by_timeframe(time_frame="week")
all_times = edhrec.get_top_commanders_by_timeframe()

# Get top commanders by color identity as generator (default number is 100)
mono_white = edhrec.get_top_commanders_by_color(colors=["w"])
colorless = edhrec.get_top_commanders_by_color(colors=["c"])
simic = edhrec.get_top_commanders_by_color(colors=["u", "g"])
izzet = edhrec.get_top_commanders_by_color(colors=["u", "r"])
esper = edhrec.get_top_commanders_by_color(colors=["u", "w", "b"])
five_colors = edhrec.get_top_commanders_by_color(colors=["u", "w", "b", "g", "r"])

```